### PR TITLE
Fix gallery orientation and show carousel buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
                 <div class="skill-card cursor-pointer bg-white/5 border border-white/10 rounded-xl p-4 gallery-item" data-skill="devops">DevOps</div>
             </div>
             <div class="project-carousel relative">
-                <button class="carousel-prev absolute left-0 top-1/2 -translate-y-1/2 p-2 bg-primary text-white rounded-full shadow hidden md:block" aria-label="Prev">
+                <button class="carousel-prev absolute left-0 top-1/2 -translate-y-1/2 p-2 bg-primary text-white rounded-full shadow hidden md:block z-10" aria-label="Prev">
                     <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
                 </button>
                 <div class="project-grid gallery-container no-scrollbar px-8">
@@ -149,7 +149,7 @@
         <div class="max-w-7xl mx-auto">
             <h2 class="section-title text-4xl md:text-6xl font-bold text-center mb-16 bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">Sở Thích</h2>
             <div class="hobby-carousel relative">
-                <button class="carousel-prev absolute left-0 top-1/2 -translate-y-1/2 p-2 bg-primary text-white rounded-full shadow hidden md:block" aria-label="Prev">
+                <button class="carousel-prev absolute left-0 top-1/2 -translate-y-1/2 p-2 bg-primary text-white rounded-full shadow hidden md:block z-10" aria-label="Prev">
                     <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6" /></svg>
                 </button>
                 <div class="hobby-grid gallery-container no-scrollbar px-8">

--- a/scripts.js
+++ b/scripts.js
@@ -51,7 +51,8 @@ function setupSkillFiltering() {
             projectCards.forEach(proj => {
                 const show = skill === 'all' || proj.dataset.skill === skill;
                 if (show) {
-                    proj.style.display = 'block';
+                    // Ensure gallery items keep their inline layout when shown
+                    proj.style.display = 'inline-block';
                     gsap.fromTo(proj, {opacity: 0, y: 30}, {opacity: 1, y: 0, duration: 0.5});
                 } else {
                     gsap.to(proj, {opacity: 0, y: 30, duration: 0.3, onComplete: () => {proj.style.display = 'none';}});


### PR DESCRIPTION
## Summary
- keep gallery items inline to maintain equal sizing
- raise left carousel button above cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68558f15d6588326b15e8ce18727164b