### PR TITLE
Fix gallery description wrap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -123,14 +123,10 @@ footer {
     line-height: 1.25rem;
 }
 
-.project-card p {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
+.card-description {
     font-size: 0.75rem;
     line-height: 1rem;
+    overflow-wrap: anywhere;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- allow long card descriptions to wrap by using `.card-description` class in CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855d25556c08326b882294dfdeb8d06