### PR TITLE
Fix gallery description word wrapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -123,14 +123,11 @@ footer {
     line-height: 1.25rem;
 }
 
-.project-card p {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
+.card-description {
     font-size: 0.75rem;
     line-height: 1rem;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- ensure words in gallery card descriptions break onto new lines

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855d25556c08326b882294dfdeb8d06