### PR TITLE
Improve profile layout with sidebar and 3D forest scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/ScrollTrigger.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/TextPlugin.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r150/three.min.js"></script>
     <script>
         tailwind.config = {
             theme: {
@@ -35,16 +36,28 @@
         <p class="hero-subtitle text-gray-300 mb-8 px-4 max-w-2xl">Learn &amp; Growth</p>
 </section>
     <!-- Profile -->
-    <section id="profile" class="h-screen flex items-center justify-center px-4 bg-slate-800">
-        <div class="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-8 max-w-md text-center space-y-4">
-            <img class="mx-auto w-32 h-32 rounded-full border-4 border-primary" src="images/profile.jpg" alt="Profile">
-            <h2 class="text-3xl font-bold">Hieu Nguyen Tan</h2>
-            <ul class="text-gray-300 space-y-1">
-                <li><strong>Birthday:</strong> 04/11/2003</li>
-                <li><strong>Horoscope:</strong> Scorpion</li>
-                <li><strong>Based in:</strong> Ho Chi Minh City, Viet Nam</li>
-                <li><strong>Relationship:</strong> Dating</li>
-            </ul>
+    <section id="profile" class="min-h-screen md:grid md:grid-cols-[300px_1fr] gap-8 items-start px-4 py-16 bg-slate-800">
+        <aside id="profile-card" class="profile-card bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-8 md:p-6 max-w-sm w-full mx-auto md:mx-0">
+            <div class="profile-image flex justify-center mb-4">
+                <div class="p-1 bg-gradient-to-tr from-primary via-accent to-secondary rounded-full">
+                    <img src="images/profile.jpg" alt="Profile" class="rounded-full w-40 h-40 object-cover">
+                </div>
+            </div>
+            <div class="profile-info text-center space-y-3">
+                <h2 class="text-3xl font-bold">Hieu Nguyen Tan</h2>
+                <ul class="text-gray-300 space-y-1">
+                    <li><strong>Birthday:</strong> 04/11/2003</li>
+                    <li><strong>Horoscope:</strong> Scorpion</li>
+                    <li><strong>Based in:</strong> Ho Chi Minh City, Viet Nam</li>
+                    <li><strong>Relationship:</strong> Dating</li>
+                </ul>
+            </div>
+        </aside>
+        <div class="profile-content flex flex-col gap-8 mt-8 md:mt-0">
+            <div id="github-stats" class="text-center md:text-left">
+                <img src="https://github-readme-stats.vercel.app/api?username=imhiju7&show_icons=true&theme=dark" alt="GitHub stats" class="mx-auto md:mx-0 rounded-xl shadow-lg">
+            </div>
+            <div id="forest-scene" class="flex-1 h-96 md:h-[32rem] relative rounded-xl overflow-hidden bg-slate-900/50"></div>
         </div>
     </section>
 

--- a/scripts.js
+++ b/scripts.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setupButtonRipple();
     setupScrollButton();
     setupCarousels();
+    initForestScene();
 });
 
 function animateHero() {
@@ -26,12 +27,25 @@ function animateHero() {
 }
 
 function animateProfile() {
-    gsap.from('#profile > div', {
-        scrollTrigger: '#profile',
-        y: 50,
-        opacity: 0,
-        duration: 1
+    const tl = gsap.timeline({
+        scrollTrigger: {
+            trigger: '#profile-card',
+            start: 'top 80%'
+        }
     });
+    tl.from('#profile-card', {y: 50, opacity: 0, duration: 0.8});
+    tl.from('#profile-card .profile-image', {
+        scale: 0,
+        opacity: 0,
+        duration: 0.8,
+        ease: 'back.out(1.7)'
+    }, '-=0.4');
+    tl.from('#profile-card .profile-info li', {
+        x: 30,
+        opacity: 0,
+        stagger: 0.2,
+        duration: 0.6
+    }, '-=0.6');
 }
 
 function animateCertificates() {
@@ -230,4 +244,78 @@ function setupCarousels() {
     document.querySelectorAll('.gallery-container').forEach(container => {
         enableDragScroll(container);
     });
+}
+
+function initForestScene() {
+    const container = document.getElementById('forest-scene');
+    if (!container || typeof THREE === 'undefined') return;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(60, container.clientWidth / container.clientHeight, 0.1, 100);
+    camera.position.set(0, 2, 5);
+
+    const renderer = new THREE.WebGLRenderer({alpha: true});
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(renderer.domElement);
+
+    const layers = [];
+    const treeGeo = new THREE.ConeGeometry(0.5, 2, 8);
+    const treeMat = new THREE.MeshStandardMaterial({color: 0x228b22});
+    for (let i = 0; i < 3; i++) {
+        const group = new THREE.Group();
+        group.position.z = -i * 2;
+        for (let j = 0; j < 20; j++) {
+            const mesh = new THREE.Mesh(treeGeo, treeMat);
+            mesh.position.set((Math.random() - 0.5) * 10, 0, (Math.random() - 0.5) * 4);
+            mesh.scale.y = 1 + Math.random();
+            group.add(mesh);
+        }
+        scene.add(group);
+        layers.push(group);
+    }
+
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(5, 10, 7);
+    scene.add(light);
+
+    function onResize() {
+        const w = container.clientWidth;
+        const h = container.clientHeight;
+        camera.aspect = w / h;
+        camera.updateProjectionMatrix();
+        renderer.setSize(w, h);
+    }
+    window.addEventListener('resize', onResize);
+
+    const mouse = {x: 0, y: 0};
+    container.addEventListener('mousemove', e => {
+        const rect = container.getBoundingClientRect();
+        mouse.x = (e.clientX - rect.left) / rect.width - 0.5;
+        mouse.y = (e.clientY - rect.top) / rect.height - 0.5;
+    });
+
+    ScrollTrigger.create({
+        trigger: container,
+        start: 'top bottom',
+        end: 'bottom top',
+        onUpdate: self => {
+            layers.forEach((layer, i) => {
+                layer.position.z = -i * 2 + self.progress * i * 4;
+            });
+        }
+    });
+
+    function animate() {
+        requestAnimationFrame(animate);
+        layers.forEach((layer, i) => {
+            gsap.to(layer.rotation, {
+                x: mouse.y * 0.3,
+                y: mouse.x * 0.3,
+                duration: 0.6,
+                overwrite: true
+            });
+        });
+        renderer.render(scene, camera);
+    }
+    animate();
 }

--- a/styles.css
+++ b/styles.css
@@ -159,3 +159,12 @@ footer {
         scroll-padding-left: 1rem;
     }
 }
+
+/* Profile section custom styles */
+.profile-card {
+    overflow: hidden;
+}
+
+#forest-scene canvas {
+    display: block;
+}


### PR DESCRIPTION
## Summary
- transform Profile section into a sidebar layout
- show GitHub stats beside the profile card
- add Three.js forest with parallax mouse tracking

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856718ba10c83269e6cf4c3c74ae7e3